### PR TITLE
Update horizontal_form.html.twig

### DIFF
--- a/Resources/views/Form/horizontal_form.html.twig
+++ b/Resources/views/Form/horizontal_form.html.twig
@@ -219,3 +219,11 @@
         {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
     {% endspaceless %}
 {% endblock button_attributes %}
+
+{% block button_row -%}
+    <div class="control-group">
+        <div class="controls">
+            {{- form_widget(form) -}}
+        </div>
+    </div>
+{%- endblock button_row %}


### PR DESCRIPTION
In order to show buttons correctly in horizontal form - you need to override button_row block